### PR TITLE
Added PHP 7 compatibility

### DIFF
--- a/server/epoll-server.php
+++ b/server/epoll-server.php
@@ -9,7 +9,7 @@ class EpollSocketServer{
 	private static $buffers;
 	private static $users=array();
 
-	function EpollSocketServer ($port){
+	function __construct($port){
 		global $errno, $errstr;
 		if (!extension_loaded('libevent')) {
 			die("Please install libevent extension firstly/n");


### PR DESCRIPTION
    Warning: Old style constructors are DEPRECATED in PHP 7.0, and will be removed in a future version. You should always use __construct() in new code.